### PR TITLE
feat: add dynamic theme toggle button to embeddable widget

### DIFF
--- a/application.py
+++ b/application.py
@@ -266,7 +266,8 @@ def embed_widget(token):
     goal = Goal.query.filter_by(embed_token=token).first()
     if not goal:
         return "Widget not found", 404
-    response = make_response(render_template('embed.html', goal=goal))
+    theme = request.args.get('theme', 'dark')
+    response = make_response(render_template('embed.html', goal=goal, theme=theme))
     response.headers['X-Frame-Options'] = 'ALLOWALL'
     return response
 

--- a/templates/embed.html
+++ b/templates/embed.html
@@ -33,6 +33,22 @@
             --transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
         }
 
+        [data-theme="light"] {
+            --bg-primary: #ffffff;
+            --bg-secondary: #f8f9fa;
+            --text-primary: #212529;
+            --text-secondary: #6c757d;
+            --text-muted: #adb5bd;
+            --accent: #00d4aa;
+            --accent-glow: rgba(0, 212, 170, 0.2);
+            --danger: #dc3545;
+            --danger-glow: rgba(220, 53, 69, 0.2);
+            --success: #28a745;
+            --glass-bg: rgba(255, 255, 255, 0.95);
+            --glass-border: rgba(0, 0, 0, 0.1);
+            --shadow-lg: 0 8px 25px rgba(0, 0, 0, 0.1);
+        }
+
         * {
             margin: 0;
             padding: 0;
@@ -220,6 +236,30 @@
             scrollbar-color: var(--accent) var(--bg-secondary);
         }
 
+        .theme-toggle {
+            position: absolute;
+            top: 10px;
+            right: 10px;
+            background: transparent;
+            border: none;
+            cursor: pointer;
+            font-size: 1.5rem;
+            color: var(--text-secondary);
+            transition: var(--transition);
+            padding: 5px;
+            border-radius: 50%;
+            width: 40px;
+            height: 40px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .theme-toggle:hover {
+            background: var(--glass-bg);
+            color: var(--text-primary);
+        }
+
         @media (max-width: 480px) {
             .widget {
                 padding: 1.5rem;
@@ -233,8 +273,9 @@
     </style>
 </head>
 
-<body>
+<body data-theme="{{ theme }}">
     <div class="widget">
+        <button id="theme-toggle" class="theme-toggle" title="Toggle theme">🌙</button>
         <div class="description">{{ goal.description }}</div>
         <div class="countdown" id="countdown">--:--:--</div>
         <div class="status" id="status">Loading...</div>
@@ -385,6 +426,25 @@
 
         document.addEventListener('DOMContentLoaded', () => {
             new EmbedWidget();
+
+            // Theme toggle functionality
+            const themeToggle = document.getElementById('theme-toggle');
+            const body = document.body;
+
+            // Set initial icon based on current theme
+            updateThemeIcon();
+
+            themeToggle.addEventListener('click', () => {
+                const currentTheme = body.getAttribute('data-theme');
+                const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
+                body.setAttribute('data-theme', newTheme);
+                updateThemeIcon();
+            });
+
+            function updateThemeIcon() {
+                const currentTheme = body.getAttribute('data-theme');
+                themeToggle.textContent = currentTheme === 'dark' ? '🌙' : '☀️';
+            }
         });
     </script>
 </body>


### PR DESCRIPTION
### Description
This PR adds a dynamic theme toggle feature to the embeddable widget.

### Changes
- **Backend (`application.py`)**
  - Reads `theme` query parameter (`light` or `dark`) from the URL.
  - Passes the theme value to the `embed.html` template (defaults to `dark`).

- **Frontend (`templates/embed.html`)**
  - Added a theme toggle button (sun/moon icon) in the widget UI.
  - Set the initial theme using `<body data-theme="{{ theme }}">`.
  - Defined CSS for both light and dark modes with `[data-theme]`.

- **JavaScript**
  - Implemented click listener for the toggle button.
  - Dynamically switches between light and dark themes in real-time.

### Acceptance Criteria
- Widget loads with the correct theme when `?theme=` parameter is provided.
- A toggle button is visible in the widget.
- Clicking the button switches the theme instantly.
- Embed URLs generated by the main dashboard continue to support a default theme parameter.

### Issue Reference
Closes #11
